### PR TITLE
Submit word modal

### DIFF
--- a/src/components/gameInfo.js
+++ b/src/components/gameInfo.js
@@ -12,9 +12,9 @@ import {
     EmbedBuilder,
 } from "discord.js";
 
-const publicGameInfoEmbed = (interaction, gameId, playerType, player) => {
+const publicGameInfoEmbed = (interaction, gameId, playerType) => {
     const author = {
-        name: `${player}'s HeadsUp Game`,
+        name: `${interaction.user.globalName}'s HeadsUp Game`,
     };
     if (interaction.user.avatar) {
         author.iconURL = `https://cdn.discordapp.com/avatars/${interaction.user.id}/${interaction.user.avatar}.png?size=256`;
@@ -28,11 +28,16 @@ const publicGameInfoEmbed = (interaction, gameId, playerType, player) => {
             {
                 name: "**Guesser**",
                 value:
-                    playerType === PLAYER_TYPE.GUESSER ? player : "Spot open!",
+                    playerType === PLAYER_TYPE.GUESSER
+                        ? interaction.user.globalName
+                        : "Spot open!",
             },
             {
                 name: "**Clue Giver**",
-                value: playerType === PLAYER_TYPE.GIVER ? player : "Spot open!",
+                value:
+                    playerType === PLAYER_TYPE.GIVER
+                        ? interaction.user.globalName
+                        : "Spot open!",
             }
         );
 
@@ -86,19 +91,22 @@ export const gameInfoComponent = (interaction, currentUserData) => {
     const gameId = getUniqueGameId();
 
     const newGame = {
+        // interaction of the owner of the game
+        // the one that executed (/headsup start)
+        ownerInteraction: interaction,
         id: gameId,
-        guesser:
-            currentUserData.embedData.playerType === PLAYER_TYPE.GUESSER
-                ? interaction.user.username
-                : null,
+        // guesser:
+        //     currentUserData.embedData.playerType === PLAYER_TYPE.GUESSER
+        //         ? interaction.user.username
+        //         : null,
         guesserId:
             currentUserData.embedData.playerType === PLAYER_TYPE.GUESSER
                 ? interaction.user.id
                 : null,
-        giver:
-            currentUserData.embedData.playerType === PLAYER_TYPE.GIVER
-                ? interaction.user.username
-                : null,
+        // giver:
+        //     currentUserData.embedData.playerType === PLAYER_TYPE.GIVER
+        //         ? interaction.user.username
+        //         : null,
         giverId:
             currentUserData.embedData.playerType === PLAYER_TYPE.GIVER
                 ? interaction.user.id
@@ -124,8 +132,7 @@ export const gameInfoComponent = (interaction, currentUserData) => {
                 publicGameInfoEmbed(
                     interaction,
                     gameId,
-                    currentUserData.embedData.playerType,
-                    interaction.user.globalName
+                    currentUserData.embedData.playerType
                 ),
             ],
             components: joinComponents,

--- a/src/components/submitWord.js
+++ b/src/components/submitWord.js
@@ -1,0 +1,61 @@
+import {
+    ButtonStyle,
+    ButtonBuilder,
+    ActionRowBuilder,
+    EmbedBuilder,
+} from "discord.js";
+
+const submitWordEmbed = (game) => {
+    const interaction = game.ownerInteraction;
+    const author = {
+        name: `${interaction.user.globalName}'s HeadsUp Game`,
+    };
+    if (interaction.user.avatar) {
+        author.iconURL = `https://cdn.discordapp.com/avatars/${interaction.user.id}/${interaction.user.avatar}.png?size=256`;
+    }
+
+    const embed = new EmbedBuilder()
+        .setColor(0xffa600)
+        .setAuthor(author)
+        .setTitle("You are the Clue Giver!")
+        .setDescription(
+            "Your job is to give clues to the other player about the given word. But first, you must pick a word!\nBe quick, the other player is waiting!"
+        )
+        .addFields(
+            {
+                name: "AI",
+                value: "Use AI to pick a random word",
+                inline: true,
+            },
+            {
+                name: "Custom",
+                value: "Submit a word of your own",
+                inline: true,
+            }
+        );
+
+    return embed;
+};
+
+const startGameActions = (game) => {
+    const ai_word = new ButtonBuilder()
+        .setCustomId(`ai_word_${game.id}`)
+        .setLabel("AI")
+        .setStyle(ButtonStyle.Primary);
+
+    const custom_word = new ButtonBuilder()
+        .setCustomId(`custom_word_${game.id}`)
+        .setLabel("Custom")
+        .setStyle(ButtonStyle.Primary);
+
+    const buttons = new ActionRowBuilder().addComponents(ai_word, custom_word);
+
+    return buttons;
+};
+
+export const submitWordComponent = async (game) => {
+    await game.activeThread.send({
+        embeds: [submitWordEmbed(game)],
+        components: [startGameActions(game)],
+    });
+};

--- a/src/components/submitWord.js
+++ b/src/components/submitWord.js
@@ -27,7 +27,7 @@ const submitWordEmbed = (game) => {
         .setAuthor(author)
         .setTitle("You are the Clue Giver!")
         .setDescription(
-            "Your job is to give clues to the other player about the given word. But first, you must pick a word!\nBe quick, the other player is waiting! (You have 60 seconds to pick a word or a random one will be generated)"
+            "Your job is to give clues to the other player about the given word. But first, you must pick a word!\nBe quick, the other player is waiting!"
         )
         .addFields(
             {

--- a/src/endGame.js
+++ b/src/endGame.js
@@ -1,0 +1,19 @@
+export const endGame = async (game, message) => {
+    const thread = game.activeThread;
+
+    await thread.setLocked(true);
+
+    thread.send({
+        content: `<@${game.giverId}>: ${message}`,
+        ephemeral: true,
+    });
+    thread.send({
+        content: `<@${game.guesserId}>: ${message}`,
+        ephemeral: true,
+    });
+
+    // delete the thread after a minute (give users time to read)
+    setTimeout(async () => {
+        await thread.delete();
+    }, 60_000);
+};

--- a/src/joinGame.js
+++ b/src/joinGame.js
@@ -1,5 +1,6 @@
 import { submitWordComponent } from "./components/submitWord.js";
 import { GAME_STATE, gamesIndex } from "./gamesIndex.js";
+import { endGame } from "./endGame.js";
 
 const checkGameExists = (interaction, gameId) => {
     let idExists = false;
@@ -113,22 +114,10 @@ export const joinGame = async (interaction, gameId) => {
             // add the player once we have the word
             await gameThread.members.add(game.guesserId);
         })
-        .catch(async () => {
-            // lock the thread and ping both users with an ephemeral message
-            await gameThread.setLocked(true);
-
-            gameThread.send({
-                content: `<@${game.giverId}>: A word could not be picked so the game could not continue. Please try again.`,
-                ephemeral: true,
-            });
-            gameThread.send({
-                content: `<@${game.guesserId}>: A word could not be picked so the game could not continue. Please try again.`,
-                ephemeral: true,
-            });
-
-            // delete the thread after a minute (give users time to read)
-            setTimeout(async () => {
-                await gameThread.delete();
-            }, 60_000);
+        .catch(() => {
+            endGame(
+                game,
+                "A word could not be picked so the game could not continue. Please try again."
+            );
         });
 };

--- a/src/joinGame.js
+++ b/src/joinGame.js
@@ -105,9 +105,7 @@ export const joinGame = async (interaction, gameId) => {
         });
     }
 
-    console.log(game);
-
-    submitWordComponent(game);
+    submitWordComponent(interaction, game);
 
     //await gameThread.members.add(game.guesserId);
 };


### PR DESCRIPTION
submitting a word should now be possible, there was a fair few changes so i might forget some things
- inside the gamesIndex we no longer store the players' usernames and only use their uids instead. less chance of having data races but also more secure since a user can't change their user id but could in theory change their username (we also werent using the usernames for anything)
- implemented a function to end the game. it locks the thread so no one can message, pings both users with a provided message and then waits 60 seconds to delete the thread.
- when the game starts only the clue giver is added to the thread. there is an embed with 2 buttons, one will generate an AI word (this is TODO) and one opens a modal where a custom word can be submitted. originally there was a 60 second timeout (and once expired an AI word would be generate) but that was very hard to get working and the logic got very messy so instead there's a 10 minute timeout and i think we implement a way for the other player to leave the game (if they wait too long for a word). once a word gets selected the guesser is added to the thread. 
- the `submitWordComponent` (the part that shows the embed with 2 buttons) returns it's own promise that *only* resolves once a word has been picked. i think this is a logical decision so (like i have done) we can `.then` on the promise and come back to it once a word has been picked, rather than having weird logic to wait for the word some other way. the only time the promise would be rejected is if the fetch to OpenAI fails, but even then we could just let the user try again.

the next steps i think are to implement the AI word and to actually have the bot listen in the thread for the guesser to have guessed the word.