### PR TITLE
Thread slash commands

### DIFF
--- a/src/commands/utility/headsup.js
+++ b/src/commands/utility/headsup.js
@@ -2,7 +2,6 @@ import { SlashCommandBuilder } from "discord.js";
 
 import { startGameComponent } from "../../components/startGame.js";
 import { joinGame } from "../../joinGame.js";
-// import { joinGameComponent } from "../../components/joinGame.js";
 
 const data = new SlashCommandBuilder()
     .setName("headsup")
@@ -24,6 +23,11 @@ const data = new SlashCommandBuilder()
 
 async function execute(interaction) {
     const subcommand = interaction.options.getSubcommand();
+    if (interaction.channel.isThread()) {
+        await handleThreadCommand(interaction, subcommand);
+        return;
+    }
+
     if (subcommand === "start") {
         await startGameComponent(interaction);
     } else if (subcommand === "join") {
@@ -31,6 +35,19 @@ async function execute(interaction) {
         const gameIdString = String(gameId).padStart(6, "0");
         joinGame(interaction, gameIdString);
     }
+}
+
+async function handleThreadCommand(interaction, subcommand) {
+    let messageContent;
+    if (subcommand === "start") {
+        messageContent = "New games must be started from the main channel.";
+    } else if (subcommand === "join") {
+        messageContent = "Games must be joined from the main channel.";
+    }
+    await interaction.reply({
+        content: messageContent,
+        ephemeral: true,
+    });
 }
 
 export { data, execute };

--- a/src/components/gameInfo.js
+++ b/src/components/gameInfo.js
@@ -60,13 +60,12 @@ const privateGameInfoEmbed = (interaction, gameId) => {
     return embed;
 };
 
-const gameInfoAction = (gameId) => {
-    const isPlaying = gamesIndex[gameId].gameState === GAME_STATE.PLAYING;
+export const joinGameComponents = (gameId, data = {}) => {
     const join = new ButtonBuilder()
         .setCustomId(`${START_GAME_IDS.JOIN_BUTTON}_${gameId}`)
         .setLabel("Join Game!")
         .setStyle(ButtonStyle.Primary)
-        .setDisabled(isPlaying);
+        .setDisabled(data.startDisabled ?? false);
 
     const joinButton = new ActionRowBuilder().addComponents(join);
 
@@ -127,7 +126,7 @@ export const gameInfoComponent = (interaction, currentUserData) => {
     }
 
     if (currentUserData.embedData.gameType === GAME_TYPE.PUBLIC) {
-        const joinComponents = gameInfoAction(gameId);
+        const joinComponents = joinGameComponents(gameId);
 
         interaction.channel.send({
             embeds: [

--- a/src/components/gameInfo.js
+++ b/src/components/gameInfo.js
@@ -56,10 +56,12 @@ const privateGameInfoEmbed = (interaction, gameId) => {
 };
 
 const gameInfoAction = (gameId) => {
+    const isPlaying = gamesIndex[gameId].gameState === GAME_STATE.PLAYING;
     const join = new ButtonBuilder()
         .setCustomId(`${START_GAME_IDS.JOIN_BUTTON}_${gameId}`)
         .setLabel("Join Game!")
-        .setStyle(ButtonStyle.Primary);
+        .setStyle(ButtonStyle.Primary)
+        .setDisabled(isPlaying);
 
     const joinButton = new ActionRowBuilder().addComponents(join);
 

--- a/src/joinGame.js
+++ b/src/joinGame.js
@@ -1,6 +1,7 @@
 import { submitWordComponent } from "./components/submitWord.js";
 import { GAME_STATE, gamesIndex } from "./gamesIndex.js";
 import { endGame } from "./endGame.js";
+import { joinGameComponents } from "./components/gameInfo.js";
 
 const checkGameExists = (interaction, gameId) => {
     let idExists = false;
@@ -78,6 +79,17 @@ export const joinGame = async (interaction, gameId) => {
     }
 
     game.gameState = GAME_STATE.PLAYING;
+
+    // disabling join button as player2 joins
+    const components = joinGameComponents(gameId, {
+        startDisabled: true,
+    });
+    const message = await interaction.channel.messages.fetch(
+        interaction.message.id
+    );
+    await message.edit({
+        components: components,
+    });
 
     const channel = interaction.guild.channels.cache.get(interaction.channelId);
 

--- a/src/joinGame.js
+++ b/src/joinGame.js
@@ -1,4 +1,5 @@
 import { GAME_STATE, gamesIndex } from "./gamesIndex.js";
+import { START_GAME_IDS } from "./components/startGame.js";
 
 const checkGameExists = (interaction, gameId) => {
     let idExists = false;
@@ -75,7 +76,7 @@ export const joinGame = async (interaction, gameId) => {
         game.guesserId = interaction.user.id;
     }
 
-    gamesIndex.gameState = GAME_STATE.PLAYING;
+    game.gameState = GAME_STATE.PLAYING;
 
     !interaction.reply({
         ephemeral: true,


### PR DESCRIPTION
headsup.js
- start and join slash commands disabled in threads, users must start or join games from channels

gameInfo.js
- conditional logic added to disable join button once game is active and no one else can join (doesn't work currently)

update: 
- join button now disabled as game started